### PR TITLE
[FIX] convert the EIP-191 message as text

### DIFF
--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -374,7 +374,16 @@ export function DAPPBrowser({
           case "personal_sign": {
             try {
               if (ledgerAPIRef.current) {
-                const message = stripHexPrefix(data.params[0]);
+                /**
+                 * The message is received as a hex string, we need to strip the
+                 * "0x" prefix and convert it to a string.
+                 * Because SDK signMessage function take the message to sign as
+                 * a Buffer of the text message
+                 */
+                const message = Buffer.from(
+                  stripHexPrefix(data.params[0]),
+                  "hex"
+                ).toString();
 
                 const signedMessage = await ledgerAPIRef.current.signMessage(
                   selectedAccount.id,

--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -367,6 +367,7 @@ export function DAPPBrowser({
             }
             break;
           }
+          // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-191.md
           // https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign
           // https://docs.walletconnect.com/json-rpc-api-methods/ethereum
           // Discussion about the diff between eth_sign and personal_sign:
@@ -375,19 +376,14 @@ export function DAPPBrowser({
             try {
               if (ledgerAPIRef.current) {
                 /**
-                 * The message is received as a hex string, we need to strip the
-                 * "0x" prefix and convert it to a string.
-                 * Because SDK signMessage function take the message to sign as
-                 * a Buffer of the text message
+                 * The message is received as a prefixed hex string.
+                 * We need to strip the "0x" prefix.
                  */
-                const message = Buffer.from(
-                  stripHexPrefix(data.params[0]),
-                  "hex"
-                ).toString();
+                const message = stripHexPrefix(data.params[0]);
 
                 const signedMessage = await ledgerAPIRef.current.signMessage(
                   selectedAccount.id,
-                  Buffer.from(message)
+                  Buffer.from(message, "hex")
                 );
                 sendResponseToDAPP({ id: data.id, result: signedMessage });
               }


### PR DESCRIPTION
The message is received as a hex string, we need to strip the "0x" prefix and convert it to a string. Because the SDK signMessage function takes the message to sign as a Buffer of the text message.

Otherwise, the message to sign is the hex representation of the message and not the plain text one