### PR TITLE
[FEATURE][LIVE-3133] forward query params to dapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
+<p align="center">
+ <img src="https://user-images.githubusercontent.com/9203826/154288895-670f5c23-81a1-4307-a080-1af83f7f8356.svg" align="center" alt="Ledger" />
+ <h2 align="center">ETH Dapp Browser</h2>
+ <p align="center">An Ethereum Dapp Browser to run your Dapp inside <a href="https://www.ledger.com/ledger-live">Ledger Live</a></p>
+</p>
+  <p align="center">
+    <a href="https://choosealicense.com/licenses/mit/">
+      <img alt="License" src="https://img.shields.io/github/license/LedgerHQ/eth-dapp-browser" />
+    </a>
+    <a href="https://github.com/LedgerHQ/eth-dapp-browser/issues">
+      <img alt="Issues" src="https://img.shields.io/github/issues/LedgerHQ/eth-dapp-browser?color=0088ff" />
+    </a>
+    <a href="https://github.com/LedgerHQ/eth-dapp-browser/pulls">
+      <img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/LedgerHQ/eth-dapp-browser?color=0088ff" />
+    </a>
+    <a href="https://discord.gg/y6nZhxv2bC">
+      <img alt="Discord" src="https://img.shields.io/discord/885256081289379850?color=1C1CE1&label=Ledger%20%7C%20Discord%20%F0%9F%91%8B%20&style=flat-square" />
+    </a>
+   
+   
+  </p>
+
+  <p align="center">
+    <a href="https://developers.ledger.com/docs/live-app/start-here/">Full documentation</a>
+    ·
+    <a href="https://github.com/LedgerHQ/eth-dapp-browser/issues/new/choose">Report Bug</a>
+    ·
+    <a href="https://github.com/LedgerHQ/eth-dapp-browser/issues/new/choose">Request Feature</a>
+  </p>
+</p>
+
+# Installation
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
@@ -12,11 +45,7 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
-
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+You can start editing the page by modifying `pages/index.ts`. The page auto-updates as you edit the file.
 
 ## Learn More
 
@@ -32,3 +61,112 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+# Usage
+
+This application is mainly used by Ledger Live to display a Dapp and provide a bridge between said Dapp and the Ledger Live client.
+
+As a Dapp developer, you can use this application through a manifest, as specified on our [developer portal](https://developers.ledger.com/docs/dapp/manifest/), to test the correct integration of your Dapp within Ledger Live.
+
+Here is an example of a manifest you could use for local test (with the `eth-dapp-browser` accessible on port `3000` and your Dapp accessible on port `4000`):
+
+```json
+{
+  "id": "test-dapp",
+  "name": "Test DApp",
+  "url": "http://localhost:3000/",
+  "params": {
+    "dappUrl": "http://localhost:4000/",
+    "nanoApp": "Ethereum",
+    "dappName": "Test DApp",
+    "networks": [
+      {
+        "currency": "ethereum",
+        "chainID": 1,
+        "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+      },
+      {
+        "currency": "bsc",
+        "chainID": 56,
+        "nodeURL": "https://bsc-dataseed.binance.org/"
+      },
+      {
+        "currency": "polygon",
+        "chainID": 137,
+        "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE"
+      },
+      {
+        "currency": "ethereum_goerli",
+        "chainID": 5,
+        "nodeURL": "https://eth-goerli.g.alchemy.com/v2/vzJoUrfWDBOdwtCL-sybfBzIfNzY0_tk"
+      }
+    ]
+  },
+  "homepageUrl": "",
+  "supportUrl": "",
+  "icon": "",
+  "platform": "all",
+  "apiVersion": "0.0.1",
+  "manifestVersion": "1",
+  "branch": "stable",
+  "categories": [],
+  "currencies": ["ethereum", "bsc"],
+  "content": {
+    "shortDescription": {
+      "en": "Test DApp"
+    },
+    "description": {
+      "en": "Test DApp"
+    }
+  },
+  "permissions": [],
+  "domains": ["https://*"]
+}
+```
+
+Know that your Dapp will **always** be accessed through the url provided under the `dappUrl` field.
+
+If you want to handle different logics for opening your Dapp (for example, opening a specific page or start your app in a specific stage based on some parameters), you can use URL query string alongside [Ledger Live deeplink](https://github.com/LedgerHQ/ledger-live/wiki/LLD:DeepLinking).
+
+Here is an example of a deeplink oppening this test Dapp with some query parameters:
+
+```
+ledgerlive://discover/test-dapp/?param1=val1&param2=val2
+```
+
+The query params `param1` and `param2` will be forwarded by the eth-dapp-browser to your Dapp (i.e: included as query parameters in your Dapp URL).
+
+Your Dapp could also automatically receive extra query params provided by the client application (Ledger Live for example).
+
+:warning: These query params are reserved, meaning you **should not** provide them as query params, either in the `dappUrl` field through the manifest or in a deeplink.
+
+Here is a list of these reserved query params and the information of wether or not they might be forwarded by the eth-dapp-browser to the Dapp:
+
+| Query param       | Passed to Dapp? |
+| ----------------- | :-------------: |
+| `params`          |                 |
+| `accountId`       |                 |
+| `theme`           |        X        |
+| `backgroundColor` |        X        |
+| `textColor`       |        X        |
+| `loadDate`        |        X        |
+| `lang`            |        X        |
+
+<!-- Table generated using https://www.tablesgenerator.com/markdown_tables# -->
+
+# Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+# License
+
+[MIT](https://choosealicense.com/licenses/mit/)
+
+---
+
+[We are hiring, join us! 🚀](https://www.ledger.com/join-us)
+
+## See also:
+
+- [Ledger Live](https://github.com/LedgerHQ/ledger-live)
+- [Live App SDK](https://github.com/LedgerHQ/live-app-sdk)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "eth-dapp-browser",
   "version": "2.0.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,19 @@
-import React from "react";
-import { useRouter } from "next/router";
 import { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
 
-import { GlobalStyle } from "../styles/GlobalStyle";
 import { StyleProvider } from "@ledgerhq/react-ui";
+import { GlobalStyle } from "../styles/GlobalStyle";
 
 import "modern-normalize";
-import { getQueryVariable } from "../src/helpers";
+import { getFirstValueFromArray } from "../src/helpers";
 
 export default function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   const router = useRouter();
 
-  const themeType = (getQueryVariable("theme", router) || "dark") as
+  const { theme } = router.query;
+
+  const themeType = (getFirstValueFromArray(theme) || "dark") as
     | "light"
     | "dark";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,41 +1,75 @@
-import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import { DAPPBrowser } from "../src/DAPPBrowser";
 import { ChainConfig } from "../src/DAPPBrowser/types";
-import { getQueryVariable } from "../src/helpers";
+import { getFirstValueFromArray } from "../src/helpers";
 
-function DappBrowserPage() {
+const DappBrowserPage = (): JSX.Element | null => {
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
-
-  const theme = getQueryVariable("theme", router);
-  const initialAccountId = getQueryVariable("accountId", router);
-  const rawParams = getQueryVariable("params", router);
-
-  const params = rawParams ? JSON.parse(rawParams) : {};
-  const chainConfigs: ChainConfig[] = params.networks;
-  const nanoApp = params.nanoApp;
-  const dappUrl = params.dappUrl;
-  const dappName = params.dappName || "DApp";
 
   useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
   }, []);
 
-  if (mounted) {
-    return dappUrl ? (
-      <DAPPBrowser
-        dappName={dappName}
-        dappUrl={dappUrl}
-        nanoApp={nanoApp}
-        theme={theme}
-        chainConfigs={chainConfigs}
-        initialAccountId={initialAccountId}
-      />
-    ) : null;
+  // Early return if the page is not mounted yet
+  if (!mounted) {
+    return null;
   }
-  return null;
-}
+
+  /**
+   * We segregate the dapp browser specific query params from the dapp query params.
+   */
+  const {
+    params: dappBrowserParams,
+    accountId,
+    ...dappQueryParams
+  } = router.query;
+
+  /**
+   * We process the dapp browser specific query params.
+   */
+  /**
+   * TODO: Handle the case where the dapp provides and uses query params also used by the dapp browser.
+   * Example: if the dapp provides a query param named "accountId" and the dapp browser also uses this query param
+   * As of today,only the first value will be taken into account and the rest will be discarded.
+   * Also, the values used by the dapp browser will not (and should not) be
+   * forwarded to the dapp (like params used by the dapp browser itself, or other
+   * live specific params such as accountId).
+   */
+  const rawParams = getFirstValueFromArray(dappBrowserParams);
+  const initialAccountId = getFirstValueFromArray(accountId);
+
+  const params = rawParams ? JSON.parse(rawParams) : {};
+
+  const {
+    networks: chainConfigs,
+    nanoApp,
+    dappUrl,
+    dappName = "DApp",
+  }: {
+    networks: ChainConfig[];
+    nanoApp: string;
+    dappUrl: string;
+    dappName: string;
+  } = params;
+
+  // Early return if no dapp provided (no dappUrl available in the query)
+  if (!dappUrl) {
+    return null;
+  }
+
+  return (
+    <DAPPBrowser
+      dappQueryParams={dappQueryParams}
+      dappName={dappName}
+      dappUrl={dappUrl}
+      nanoApp={nanoApp}
+      chainConfigs={chainConfigs}
+      initialAccountId={initialAccountId}
+    />
+  );
+};
 
 export default DappBrowserPage;

--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -93,10 +93,10 @@ const DappIframe = styled.iframe`
 type DAPPBrowserProps = {
   dappUrl: string;
   dappName: string;
-  theme?: string;
   nanoApp?: string;
   initialAccountId: string | undefined;
   chainConfigs: ChainConfig[];
+  dappQueryParams: { [x: string]: string | string[] | undefined };
 };
 
 type DAPPBrowserState = {
@@ -120,10 +120,10 @@ const initialState = {
 export function DAPPBrowser({
   dappUrl,
   dappName,
-  theme,
   nanoApp,
   initialAccountId,
   chainConfigs,
+  dappQueryParams,
 }: DAPPBrowserProps): React.ReactElement {
   const [state, setState] = useState<DAPPBrowserState>(initialState);
   const {
@@ -162,11 +162,27 @@ export function DAPPBrowser({
   const dappURL = useMemo(() => {
     const urlObject = new URL(dappUrl);
 
-    if (theme) {
-      urlObject.searchParams.set("theme", theme);
+    /**
+     * Append each dapp specific query param to the url.
+     * This takes into account query params that might be defined multiple times
+     * ex: ?foo=bar&foo=baz
+     */
+    if (dappQueryParams) {
+      Object.entries(dappQueryParams).forEach(([key, val]) => {
+        if (!val) {
+          return;
+        }
+
+        if (Array.isArray(val)) {
+          val.forEach((v) => urlObject.searchParams.append(key, v));
+          return;
+        }
+
+        urlObject.searchParams.append(key, val);
+      });
     }
     return urlObject;
-  }, [dappUrl]);
+  }, [dappUrl, dappQueryParams]);
   const chainConfig = useMemo(
     () =>
       selectedAccount

--- a/src/components/AccountSelector.tsx
+++ b/src/components/AccountSelector.tsx
@@ -1,6 +1,6 @@
-import Select, { components, OptionTypeBase } from "react-select";
-import React, { useMemo, useCallback } from "react";
 import Image from "next/image";
+import { useCallback, useMemo } from "react";
+import Select, { components, OptionTypeBase } from "react-select";
 import styled, { useTheme } from "styled-components";
 
 import { Account } from "@ledgerhq/live-app-sdk";
@@ -124,9 +124,8 @@ function AccountSelector({
   accounts,
   onAccountChange,
   selectedAccount,
-}: AccountSelectorProps) {
+}: AccountSelectorProps): JSX.Element {
   const theme = useTheme();
-  console.log(theme);
   const options = useMemo(
     () => accounts.map((account) => fromAccountToOption(account)),
     [accounts]

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,30 +1,8 @@
-import { NextRouter } from "next/router";
-
-export function getQueryVariable(
-  name: string,
-  router: NextRouter,
-  formater?: (variable: string) => any
-): string | undefined {
-  const queryVariable = router.query[name];
-  if (queryVariable) {
-    const value = !Array.isArray(queryVariable)
-      ? queryVariable
-      : queryVariable[0];
-    if (formater) {
-      return formater(value);
-    }
-    return value;
+export const getFirstValueFromArray = (
+  value: string | string[] | undefined
+): string | undefined => {
+  if (Array.isArray(value)) {
+    return value[0];
   }
-  return undefined;
-}
-
-export function getQueryArray(
-  name: string,
-  router: NextRouter
-): string[] | undefined {
-  const queryVariable = router.query[name];
-  if (queryVariable) {
-    return Array.isArray(queryVariable) ? queryVariable : [queryVariable];
-  }
-  return undefined;
-}
+  return value;
+};


### PR DESCRIPTION
Forward URL query params to the Dapp launched inside the dapp browser, removing the dapp-browser specific ones beforehand.

This is mainly used in the context of opening a Dapp through deeplinking, since the query params can be dynamic in this case and not present inside the manifest for said dapp.

This PR also provide a proper Readme with context and documentation regarding the application

Cf. this PR for additional context:
- https://github.com/LedgerHQ/ledger-live/pull/985

https://ledgerhq.atlassian.net/browse/LIVE-3133