### PR TITLE
Removed loading dapp overlay

### DIFF
--- a/manifest-local.json
+++ b/manifest-local.json
@@ -1,0 +1,71 @@
+{
+    "id": "lmarket",
+    "name": "[ Ledger ] Market",
+    "private": false,
+    "url": "http://localhost:3000",
+    "params": {
+      "dappUrl": "https://market.ledger.com?embed=1",
+      "nanoApp": "[ L ] Market",
+      "dappName": "[ Ledger ] Market",
+      "networks": [
+        {
+          "currency": "ethereum",
+          "chainID": 1,
+          "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+        }
+      ]
+    },
+    "homepageUrl": "https://market.ledger.com/",
+    "supportUrl": "https://market.ledger.com/",
+    "icon": "https://cdn.live.ledger.com/icons/platform/lmarket.png",
+    "platform": "all",
+    "apiVersion": "^1.0.0 || ~0.0.1",
+    "manifestVersion": "1",
+    "branch": "stable",
+    "categories": [
+      "nft"
+    ],
+    "currencies": [
+      "ethereum"
+    ],
+    "content": {
+      "shortDescription": {
+        "en": "[ Ledger ] Market is the most secure platform for artists and brands to release their NFTs"
+      },
+      "description": {
+        "en": "[ L ] Market is the most secure platform for artists and brands to release their NFTs. For first access to exclusive collaborations, and Ledger hardware, software and services, become a [ Ledger ] Market Pass holder."
+      }
+    },
+    "permissions": [
+      {
+        "method": "account.list",
+        "params": {
+          "currencies": [
+            "ethereum"
+          ]
+        }
+      },
+      {
+        "method": "account.request",
+        "params": {
+          "currencies": [
+            "ethereum"
+          ]
+        }
+      },
+      {
+        "method": "transaction.sign",
+        "params": {
+          "nanoApp": [
+            "[ L ] Market"
+          ]
+        }
+      },
+      {
+        "method": "transaction.broadcast"
+      }
+    ],
+    "domains": [
+      "https://*"
+    ]
+  }

--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -102,7 +102,6 @@ type DAPPBrowserProps = {
 type DAPPBrowserState = {
   accounts: Account[];
   selectedAccount: Account | undefined;
-  clientLoaded: boolean;
   fetchingAccounts: boolean;
   connected: boolean;
   cookiesBlocked: boolean;
@@ -111,7 +110,6 @@ type DAPPBrowserState = {
 const initialState = {
   accounts: [],
   selectedAccount: undefined,
-  clientLoaded: false,
   fetchingAccounts: false,
   connected: false,
   cookiesBlocked: false,
@@ -129,7 +127,6 @@ export function DAPPBrowser({
   const {
     accounts,
     selectedAccount,
-    clientLoaded,
     connected,
     fetchingAccounts,
     cookiesBlocked,
@@ -456,13 +453,6 @@ export function DAPPBrowser({
     ]
   );
 
-  const setClientLoaded = useCallback(() => {
-    setState((currentState) => ({
-      ...currentState,
-      clientLoaded: true,
-    }));
-  }, [setState]);
-
   const requestAccount = useCallback(async () => {
     const enabledCurrencies = chainConfigs.map(
       (chainConfig) => chainConfig.currency
@@ -596,6 +586,8 @@ export function DAPPBrowser({
     return <CookiesBlocked />;
   }
 
+  const showOverlay = !connected || fetchingAccounts || accounts.length === 0;
+
   return (
     <AppLoaderPageContainer>
       {!!accounts.length && (
@@ -608,7 +600,7 @@ export function DAPPBrowser({
         </ControlBar>
       )}
       <DappContainer>
-        <CSSTransition in={clientLoaded} timeout={300} classNames="overlay">
+        <CSSTransition in={showOverlay} timeout={300} classNames="overlay">
           <Overlay>
             {!connected ? (
               <Loader>
@@ -627,21 +619,13 @@ export function DAPPBrowser({
                   {"Add Account"}
                 </Button>
               </Flex>
-            ) : (
-              <Loader>
-                <Text
-                  variant="h5"
-                  color="neutral.c100"
-                >{`Loading ${dappName} ...`}</Text>
-              </Loader>
-            )}
+            ) : null}
           </Overlay>
         </CSSTransition>
         {connected && accounts.length > 0 ? (
           <DappIframe
             ref={iframeRef}
             src={dappURL.toString()}
-            onLoad={setClientLoaded}
             allow="clipboard-read; clipboard-write"
           />
         ) : null}

--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -17,7 +17,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import CSSTransition from "react-transition-group/CSSTransition";
 import styled, { keyframes } from "styled-components";
 import AccountRequest from "../components/AccountRequest";
 import AccountSelector from "../components/AccountSelector";
@@ -599,8 +598,9 @@ export function DAPPBrowser({
         </ControlBar>
       )}
       <DappContainer>
-        <CSSTransition in={showOverlay} timeout={300} classNames="overlay">
-          <Overlay>
+        {
+          showOverlay ? (
+            <Overlay>
             {!connected ? (
               <Loader>
                 <Text color="neutral.c100">{"Connecting ..."}</Text>
@@ -620,7 +620,8 @@ export function DAPPBrowser({
               </Flex>
             ) : null}
           </Overlay>
-        </CSSTransition>
+          ) : null
+        }
         {connected && accounts.length > 0 ? (
           <DappIframe
             ref={iframeRef}

--- a/src/DAPPBrowser/index.tsx
+++ b/src/DAPPBrowser/index.tsx
@@ -117,7 +117,6 @@ const initialState = {
 
 export function DAPPBrowser({
   dappUrl,
-  dappName,
   nanoApp,
   initialAccountId,
   chainConfigs,


### PR DESCRIPTION
This PR prevent the loading state from being controlled by the iframe's `onload` callback.
Main reason for doing this is that the `onload` callback is a bit unpredictable, and some unoptimized pages could be considered loading for a while even though they are in an usable state.